### PR TITLE
fix: Add readline support and tests

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -33,15 +33,19 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-test.txt
 
-      # Step 4: Build the pug interpreter
-      - name: Build pug interpreter
-        run: make -C src
+      # Step 4: Install libedit
+      - name: Install libedit-dev
+        run: sudo apt-get update && sudo apt-get install -y libedit-dev
 
-      # Step 5: Run the tests with XML reporting
+      # Step 5: Build the pug interpreter with readline support
+      - name: Build pug interpreter
+        run: make CFLAGS="-DUSE_READLINE=1" LDFLAGS="-ledit" -C src
+
+      # Step 6: Run the tests with XML reporting
       - name: Run interpreter tests with XML reports
         run: make -C src test-reports
 
-      # Step 6: Upload test results to GitHub
+      # Step 7: Upload test results to GitHub
       - name: Publish Test Results
         uses: dorny/test-reporter@v1
         if: success() || failure()    # run this step even if tests fail
@@ -51,7 +55,7 @@ jobs:
           reporter: java-junit
           fail-on-error: false  # Changed to false to prevent workflow failure if reporting fails
 
-      # Step 6b: Alternative test result publishing (GitHub summary)
+      # Step 8: Alternative test result publishing (GitHub summary)
       - name: Create Test Summary
         if: success() || failure()
         run: |
@@ -60,7 +64,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Full test reports are available as artifacts." >> $GITHUB_STEP_SUMMARY
 
-      # Step 7: Upload HTML reports as artifacts
+      # Step 9: Upload HTML reports as artifacts
       - name: Upload HTML Test Reports
         uses: actions/upload-artifact@v4
         if: always()  # Upload even if tests fail

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Step 1.1: Install libedit
+      - name: Install libedit-dev
+        run: sudo apt-get update && sudo apt-get install -y libedit-dev
+
       # Step 2: Set up Python
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Step 5: Build the pug interpreter with readline support
       - name: Build pug interpreter
-        run: make CFLAGS="-DUSE_READLINE=1" LDFLAGS="-ledit" -C src
+        run: make CFLAGS="-DUSE_READLINE=1" LDFLAGS="-ledit -lm" -C src
 
       # Step 6: Run the tests with XML reporting
       - name: Run interpreter tests with XML reports

--- a/.github/workflows/test-multiplatforms.yml
+++ b/.github/workflows/test-multiplatforms.yml
@@ -125,7 +125,7 @@ jobs:
 
       # Step 3: Cross-compile pug.exe for Windows
       - name: Cross-compile pug.exe for Windows
-        run: CC=x86_64-w64-mingw32-gcc LDFLAGS="-lm -static" make -C src pug
+        run: CC=x86_64-w64-mingw32-gcc CFLAGS="" LDFLAGS="-lm -static" make -C src pug
 
       # Step 4: Upload Windows binary as artifact
       - name: Upload Windows artifacts

--- a/.github/workflows/test-multiplatforms.yml
+++ b/.github/workflows/test-multiplatforms.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Step 5: Build the pug interpreter with readline support
       - name: Build pug interpreter
-        run: make CFLAGS="-DUSE_READLINE=1" LDFLAGS="-ledit" -C src
+        run: make CFLAGS="-DUSE_READLINE=1" LDFLAGS="-ledit -lm" -C src
 
       # Step 6: Run the tests with XML reporting
       - name: Run interpreter tests with XML reports
@@ -88,7 +88,7 @@ jobs:
 
       # Step 4: Build the pug interpreter with readline support
       - name: Build pug interpreter
-        run: make CFLAGS="-DUSE_READLINE=1 -Wno-deprecated-non-prototype -Wno-parentheses -Wimplicit-function-declaration -Wmain-return-type" LDFLAGS="-ledit" -C src
+        run: make CFLAGS="-DUSE_READLINE=1 -Wno-deprecated-non-prototype -Wno-parentheses -Wimplicit-function-declaration -Wmain-return-type" LDFLAGS="-ledit -lm" -C src
 
       # Step 5: Run the tests with XML reporting
       - name: Run interpreter tests with XML reports

--- a/.github/workflows/test-multiplatforms.yml
+++ b/.github/workflows/test-multiplatforms.yml
@@ -36,15 +36,19 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-test.txt
 
-      # Step 4: Build the pug interpreter
-      - name: Build pug interpreter
-        run: make -C src
+      # Step 4: Install libedit
+      - name: Install libedit-dev
+        run: sudo apt-get update && sudo apt-get install -y libedit-dev
 
-      # Step 5: Run the tests with XML reporting
+      # Step 5: Build the pug interpreter with readline support
+      - name: Build pug interpreter
+        run: make CFLAGS="-DUSE_READLINE=1" LDFLAGS="-ledit" -C src
+
+      # Step 6: Run the tests with XML reporting
       - name: Run interpreter tests with XML reports
         run: make -C src test-reports
 
-      # Step 6: Upload test results to GitHub
+      # Step 7: Upload test results to GitHub
       - name: Publish Test Results
         uses: dorny/test-reporter@v1
         if: success() || failure()    # run this step even if tests fail
@@ -54,7 +58,7 @@ jobs:
           reporter: java-junit
           fail-on-error: false  # Changed to false to prevent workflow failure if reporting fails
 
-      # Step 7: Upload HTML reports as artifacts
+      # Step 8: Upload HTML reports as artifacts
       - name: Upload HTML Test Reports
         uses: actions/upload-artifact@v4
         if: always()  # Upload even if tests fail
@@ -82,9 +86,9 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-test.txt
 
-      # Step 4: Build the pug interpreter
+      # Step 4: Build the pug interpreter with readline support
       - name: Build pug interpreter
-        run: make CFLAGS="-Wno-deprecated-non-prototype -Wno-parentheses -Wimplicit-function-declaration -Wmain-return-type" -C src
+        run: make CFLAGS="-DUSE_READLINE=1 -Wno-deprecated-non-prototype -Wno-parentheses -Wimplicit-function-declaration -Wmain-return-type" LDFLAGS="-ledit" -C src
 
       # Step 5: Run the tests with XML reporting
       - name: Run interpreter tests with XML reports

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,8 +27,8 @@ COBJECTS	= gofc.o cbuiltin.o cmachine.o $(OBJECTS)
 CC		?= gcc
 
 #CFLAGS		= -DUSE_READLINE=1
-CFLAGS		?=
-LDFLAGS    	?= -lm
+CFLAGS		?= -DUSE_READLINE=1
+LDFLAGS    	?= -lm -ledit
 OPTFLAGS	= -O
 OPT1		=
 #OPT1		= -O1

--- a/test/test_pug.py
+++ b/test/test_pug.py
@@ -202,44 +202,47 @@ class TestPugInterpreter(unittest.TestCase):
         if not self.process:
             self.fail("Process not initialized")
 
-        # 1. Test History Navigation
-        self.process.sendline("1+1")
-        self.process.expect_exact("2")
-        self.process.expect(PUG_PROMPT)
+        try:
+            # 1. Test History Navigation
+            self.process.sendline("1+1")
+            self.process.expect_exact("2")
+            self.process.expect(PUG_PROMPT)
 
-        self.process.sendline("2+2")
-        self.process.expect_exact("4")
-        self.process.expect(PUG_PROMPT)
+            self.process.sendline("2+2")
+            self.process.expect_exact("4")
+            self.process.expect(PUG_PROMPT)
 
-        # Press UP to get "2+2", then UP again for "1+1"
-        self.process.send(UP_ARROW)
-        self.process.expect_exact("2+2")
+            # Press UP to get "2+2", then UP again for "1+1"
+            self.process.send(UP_ARROW)
+            self.process.expect_exact("2+2")
 
-        self.process.send(UP_ARROW)
-        self.process.expect_exact("1+1")
+            self.process.send(UP_ARROW)
+            self.process.expect_exact("1+1")
 
-        # Execute the recalled command
-        self.process.sendline("") # send enter
-        self.process.expect_exact("2")
-        self.process.expect(PUG_PROMPT)
+            # Execute the recalled command
+            self.process.sendline("") # send enter
+            self.process.expect_exact("2")
+            self.process.expect(PUG_PROMPT)
 
-        # 2. Test Cursor Movement and Editing
-        # Clear the line first (Ctrl+U)
-        self.process.send("\x15")
-        self.process.send("10+20")
-        self.process.expect_exact("10+20")
+            # 2. Test Cursor Movement and Editing
+            # Clear the line first (Ctrl+U)
+            self.process.send("\x15")  # \x15 is NAK (Negative Acknowledge), which clears the line (Ctrl+U).
+            self.process.send("10+20")
+            self.process.expect_exact("10+20")
 
-        # Move left, insert '3', move right, insert '4'
-        self.process.send(LEFT_ARROW) # Cursor is now between 2 and 0
-        self.process.send("3")         # Line becomes 10+230
-        self.process.send(RIGHT_ARROW) # Cursor is now at the end of the line
-        self.process.send("4")         # Line becomes 10+2304
+            # Move left, insert '3', move right, insert '4'
+            self.process.send(LEFT_ARROW) # Cursor is now between 2 and 0
+            self.process.send("3")         # Line becomes 10+230
+            self.process.send(RIGHT_ARROW) # Cursor is now at the end of the line
+            self.process.send("4")         # Line becomes 10+2304
 
-        # Now, execute the command "10+2304" by sending a newline
-        self.process.sendline("")
-        # The result of 10 + 2304 is 2314
-        self.process.expect_exact("2314")
-        self.process.expect(PUG_PROMPT)
+            # Now, execute the command "10+2304" by sending a newline
+            self.process.sendline("")
+            # The result of 10 + 2304 is 2314
+            self.process.expect_exact("2314")
+            self.process.expect(PUG_PROMPT)
+        except (pexpect.TIMEOUT, pexpect.EOF) as e:
+            self.fail(f"Readline test failed with exception: {e}")
 
 
 # --- Dynamic Test Generation Logic ---


### PR DESCRIPTION
Fixes #11

This PR introduces readline support for an improved interactive experience and adds the necessary tests and CI updates.

- __Readline Support:__

  - Integrates `libedit` to provide command-line history (up/down arrows) and cursor navigation (left/right arrows) in the Pug interpreter.
  - Updates the build process to include the necessary flags for compiling with `readline` support.

- __Enhanced Testing:__

  - Adds a new test suite (`test_02_readline_support`) to verify the functionality of the new command-line editing features - currently works for linux/mac only. `wexpect`, the windows counterpart to `pexpect` doesn't have access to pseudoterminals it seems.

- __CI/CD:__

  - Modifies the GitHub Actions workflows to install `libedit-dev` and build the interpreter with `readline` support, ensuring that the new features are tested in the CI environment.
